### PR TITLE
Allow passing the package version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
     description: Application deployment configuration for SONAR consumption
     required: false
     default: .scoop/app.yaml
+  version:
+    description: The SONAR package version
+    required: false
 runs:
   using: node12
   main: dist/index.js

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ async function main () {
   const config = {
     defaultEnvironment: core.getInput('default_environment'),
     appManifest: core.getInput('app_manifest'),
-    version: `${core.getInput('ref')}-test`,
+    version: core.getInput('version') || `${core.getInput('ref')}-test`,
     ciUrlPrefix: core.getInput('ci_url_prefix'),
     gitRef: core.getInput('ref'),
     branch: core.getInput('branch'),


### PR DESCRIPTION
We're currently in a spot where we know we want to drop the SHA-test suffix, but were still dependent on it in many places. The change here will allow us to pass the version as just the SHA until we get moved over to the new deploy workflow in which case we can make the action use the SHA as the default.

We got an image pull error for airflow when deploying from a branch because the test sidecar containers are pushed without tags so they're probably @latest. The final package gets around this because the images are published on merge to master with a haiku id.