### PR TITLE
Require version when using the action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     default: .scoop/app.yaml
   version:
     description: The SONAR package version
-    required: false
+    required: true
 runs:
   using: node12
   main: dist/index.js

--- a/src/deploy.test.js
+++ b/src/deploy.test.js
@@ -37,7 +37,7 @@ const getContext = (extensions = {}) => _.merge({
 const getConfig = (extensions = {}) => _.merge({
   defaultEnvironment: 'staging',
   appManifest: 'test/fixtures/app.yaml',
-  version: '124cb6d97d86ed4b93eccc95a8ce4ff58a24f843-test',
+  version: '124cb6d97d86ed4b93eccc95a8ce4ff58a24f843',
   ciUrlPrefix: 'https://app.circleci.com/pipelines/github/',
   gitRef: '124cb6d97d86ed4b93eccc95a8ce4ff58a24f843',
   branch: 'feature',

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ async function main () {
   const config = {
     defaultEnvironment: core.getInput('default_environment'),
     appManifest: core.getInput('app_manifest'),
-    version: core.getInput('version') || `${core.getInput('ref')}-test`,
+    version: core.getInput('version'),
     ciUrlPrefix: core.getInput('ci_url_prefix'),
     gitRef: core.getInput('ref'),
     branch: core.getInput('branch'),


### PR DESCRIPTION
Requires the version to be passed to the action. This will set us up nicely for when we move away from using the -test suffix for referencing intermediate docker images (which we also use for branch deployment)

Fixes https://takescoop.atlassian.net/browse/PLATFORM-2170

Tested this [successfully](https://github.com/TakeScoop/sonar-www/pull/279) on sonar-www