### PR TITLE
Add udpate-semver workflow

### DIFF
--- a/.github/workflows/update-semver.yml
+++ b/.github/workflows/update-semver.yml
@@ -1,0 +1,15 @@
+name: Update Semver
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+jobs:
+  update-semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haya14busa/action-update-semver@v1
+        with:
+          major_version_tag_only: true 

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ git tag v1.0.1
 git push --tags
 ```
 
-A generalized major version tag (ex. `v1`) is automatically synced to point to any released minor and patch versions through the [update-semver workflow](https://github.com/TakeScoop/sonar-deploy-action/blob/master/.github/workflows/update-semver.yml)
+A generalized major version tag (ex. `v1`) is automatically synced to point to any released minor and patch versions through the [update-semver workflow](.github/workflows/update-semver.yml)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # sonar-deploy-action
 
 A Github action to deploy applications to SONAR.
+
+## Release
+
+```
+git tag v1.0.1
+git push --tags
+```
+
+A generalized major version tag (ex. `v1`) is automatically synced to point to any released minor and patch versions through the [update-semver workflow](https://github.com/TakeScoop/sonar-deploy-action/blob/master/.github/workflows/update-semver.yml)


### PR DESCRIPTION
This workflow will allow repos to consume a generic major version (ex `v1`) which will be consistently updated anytime a corresponding minor or patch tag is pushed. This will give us the benefit not having to bump dependent repos for most cases while still allowing us to release breaking changes without disruption